### PR TITLE
Blank out input when losing focus

### DIFF
--- a/src/Main.elm
+++ b/src/Main.elm
@@ -175,7 +175,7 @@ update msg model =
                 ( model, Cmd.none )
 
         InputBlur ->
-            ( { model | showDropdown = False, focused = False }, Cmd.none )
+            ( { model | showDropdown = False, focused = False, searchString = "" }, Cmd.none )
 
         InputFocus ->
             ( { model | showDropdown = True }, Cmd.none )


### PR DESCRIPTION
Right now if you unfocus the much-select without actually choosing an option, it continues to show what you typed in BUT the _value_ of the input remains blank. This will likely cause confusion (e.g. when creating a segment) because what gets persisted won't match what's shown on the screen.


# CHANGES

When tabbing away, clear the input field (so it doesn't look like something is selected).

https://user-images.githubusercontent.com/1217052/136054115-860867e2-f71c-4bfb-bef0-6df5d78035eb.mov


Same when clicking away.

https://user-images.githubusercontent.com/1217052/136054092-b7428581-6891-4dca-b671-35a2bd327470.mov


When submitting (enter key) it selects the highlighted one and shows that.

https://user-images.githubusercontent.com/1217052/136054347-28bda34b-33b0-4dc5-bf94-2ab510e5cfd2.mov
