### PR TITLE
Markup changes for no options

### DIFF
--- a/public/multi-select.html
+++ b/public/multi-select.html
@@ -57,6 +57,14 @@
     </much-select>
 
   </div>
+
+  <div id="much-select-with-no-options">
+    <h3>No Options</h3>
+    <p>What does the drop down look like if you have no options</p>
+    <much-select multi-select="" allow-custom-options="">
+    </much-select>
+
+  </div>
 </div>
 
 <script src="./index.js" type="module"></script>

--- a/public/slots.html
+++ b/public/slots.html
@@ -200,6 +200,16 @@
     </script>
   </div>
 
+  <div>
+    <h3>No options</h3>
+    <p>
+      Override what shows up if there are no options
+    </p>
+    <much-select>
+      <div slot="no-options">Nothing to see here...</div>
+    </much-select>
+  </div>
+
 </div>
 
 <script src="./index.js" type="module"></script>

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -834,7 +834,11 @@ view model =
                     ]
                     (optionsToValuesHtml model.options
                         ++ [ inputFilter
-                           , rightSlotHtml model.rightSlot model.focused model.disabled hasOptionSelected
+                           , rightSlotHtml
+                                model.rightSlot
+                                model.focused
+                                model.disabled
+                                hasOptionSelected
                            ]
                     )
                 , dropdown model
@@ -962,12 +966,16 @@ dropdown : Model -> Html Msg
 dropdown model =
     let
         optionsHtml =
-            optionsToDropdownOptions
-                DropdownMouseOverOption
-                DropdownMouseOutOption
-                DropdownMouseClickOption
-                model.selectionMode
-                model.optionsForTheDropdown
+            if List.isEmpty model.optionsForTheDropdown then
+                [ div [ class "option disabled" ] [ node "slot" [ name "no-options" ] [ text "No available options" ] ] ]
+
+            else
+                optionsToDropdownOptions
+                    DropdownMouseOverOption
+                    DropdownMouseOutOption
+                    DropdownMouseClickOption
+                    model.selectionMode
+                    model.optionsForTheDropdown
 
         dropdownFooterHtml =
             if List.length model.optionsForTheDropdown < List.length model.options then
@@ -995,7 +1003,7 @@ dropdown model =
     if model.disabled then
         text ""
 
-    else if model.showDropdown && not (List.isEmpty model.optionsForTheDropdown) && not (List.isEmpty optionsHtml) then
+    else if model.showDropdown && not (List.isEmpty optionsHtml) then
         div
             ([ id "dropdown"
              , class "showing"


### PR DESCRIPTION
When there are no options, put something in the dropdown.

Adding a slot to override what the "no options" state looks like.