### PR TITLE
Hidden input slot

### DIFF
--- a/dist/much-select-debug.js
+++ b/dist/much-select-debug.js
@@ -654,6 +654,15 @@ class MuchSelect extends HTMLElement {
         `In single select mode we are expecting a single value, instead we got ${valuesTuple.length}`
       );
     }
+
+    if (!this.eventsOnlyMode) {
+      const hiddenValueInput = this.querySelector(
+        "[slot='hidden-value-input']"
+      );
+      if (hiddenValueInput) {
+        hiddenValueInput.setAttribute("value", this.parsedSelectedValue);
+      }
+    }
   }
 
   customOptionSelected(values) {

--- a/dist/much-select-debug.js
+++ b/dist/much-select-debug.js
@@ -480,6 +480,8 @@ class MuchSelect extends HTMLElement {
       slot.addEventListener("slotchange", this._onSlotChange);
     }
 
+    this.updateHiddenInputValueSlot();
+
     this._connected = true;
   }
 
@@ -499,6 +501,17 @@ class MuchSelect extends HTMLElement {
         app.ports.optionsChangedReceiver.send(optionsJson);
         this.updateDimensions();
       });
+    }
+  }
+
+  updateHiddenInputValueSlot() {
+    if (!this.eventsOnlyMode) {
+      const hiddenValueInput = this.querySelector(
+        "[slot='hidden-value-input']"
+      );
+      if (hiddenValueInput) {
+        hiddenValueInput.setAttribute("value", this.parsedSelectedValue);
+      }
     }
   }
 
@@ -655,14 +668,7 @@ class MuchSelect extends HTMLElement {
       );
     }
 
-    if (!this.eventsOnlyMode) {
-      const hiddenValueInput = this.querySelector(
-        "[slot='hidden-value-input']"
-      );
-      if (hiddenValueInput) {
-        hiddenValueInput.setAttribute("value", this.parsedSelectedValue);
-      }
-    }
+    this.updateHiddenInputValueSlot();
   }
 
   customOptionSelected(values) {
@@ -778,6 +784,8 @@ class MuchSelect extends HTMLElement {
       // noinspection JSUnresolvedVariable
       this.appPromise.then((app) => app.ports.valueChangedReceiver.send([]));
     }
+
+    this.updateHiddenInputValueSlot();
   }
 
   set parsedSelectedValue(values) {

--- a/dist/much-select.js
+++ b/dist/much-select.js
@@ -654,6 +654,15 @@ class MuchSelect extends HTMLElement {
         `In single select mode we are expecting a single value, instead we got ${valuesTuple.length}`
       );
     }
+
+    if (!this.eventsOnlyMode) {
+      const hiddenValueInput = this.querySelector(
+        "[slot='hidden-value-input']"
+      );
+      if (hiddenValueInput) {
+        hiddenValueInput.setAttribute("value", this.parsedSelectedValue);
+      }
+    }
   }
 
   customOptionSelected(values) {

--- a/dist/much-select.js
+++ b/dist/much-select.js
@@ -480,6 +480,8 @@ class MuchSelect extends HTMLElement {
       slot.addEventListener("slotchange", this._onSlotChange);
     }
 
+    this.updateHiddenInputValueSlot();
+
     this._connected = true;
   }
 
@@ -499,6 +501,17 @@ class MuchSelect extends HTMLElement {
         app.ports.optionsChangedReceiver.send(optionsJson);
         this.updateDimensions();
       });
+    }
+  }
+
+  updateHiddenInputValueSlot() {
+    if (!this.eventsOnlyMode) {
+      const hiddenValueInput = this.querySelector(
+        "[slot='hidden-value-input']"
+      );
+      if (hiddenValueInput) {
+        hiddenValueInput.setAttribute("value", this.parsedSelectedValue);
+      }
     }
   }
 
@@ -655,14 +668,7 @@ class MuchSelect extends HTMLElement {
       );
     }
 
-    if (!this.eventsOnlyMode) {
-      const hiddenValueInput = this.querySelector(
-        "[slot='hidden-value-input']"
-      );
-      if (hiddenValueInput) {
-        hiddenValueInput.setAttribute("value", this.parsedSelectedValue);
-      }
-    }
+    this.updateHiddenInputValueSlot();
   }
 
   customOptionSelected(values) {
@@ -778,6 +784,8 @@ class MuchSelect extends HTMLElement {
       // noinspection JSUnresolvedVariable
       this.appPromise.then((app) => app.ports.valueChangedReceiver.send([]));
     }
+
+    this.updateHiddenInputValueSlot();
   }
 
   set parsedSelectedValue(values) {

--- a/public/slots.html
+++ b/public/slots.html
@@ -210,6 +210,28 @@
     </much-select>
   </div>
 
+  <div>
+    <h3>Hidden Input</h3>
+    <p>
+      If you want to use a much select in a traditional HTML form you can use the <code>hidden-value-input</code> slot. If you put a hidden input in that slot, it's value will mirror that of the much-select.
+    </p>
+    <much-select>
+      <select slot="select-input">
+        <option>Alberta</option>
+        <option>British Columbia</option>
+        <option>Manitoba</option>
+        <option>New Brunswick</option>
+        <option>Newfoundland and Labrador</option>
+        <option>Nova Scotia</option>
+        <option>Ontario</option>
+        <option>Prince Edward Island</option>
+        <option>Quebec</option>
+        <option>Saskatchewan</option>
+      </select>
+      <input slot="hidden-value-input" type="hidden" name="my-special-value">
+    </much-select>
+  </div>
+
 </div>
 
 <script src="./index.js" type="module"></script>

--- a/public/slots.html
+++ b/public/slots.html
@@ -215,6 +215,9 @@
     <p>
       If you want to use a much select in a traditional HTML form you can use the <code>hidden-value-input</code> slot. If you put a hidden input in that slot, it's value will mirror that of the much-select.
     </p>
+    <p>
+      You can use your browser's developer tools to see the hidden input and watch its value change as you change the much-select's value.
+    </p>
     <much-select>
       <select slot="select-input">
         <option>Alberta</option>

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -654,6 +654,15 @@ class MuchSelect extends HTMLElement {
         `In single select mode we are expecting a single value, instead we got ${valuesTuple.length}`
       );
     }
+
+    if (!this.eventsOnlyMode) {
+      const hiddenValueInput = this.querySelector(
+        "[slot='hidden-value-input']"
+      );
+      if (hiddenValueInput) {
+        hiddenValueInput.setAttribute("value", this.parsedSelectedValue);
+      }
+    }
   }
 
   customOptionSelected(values) {

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -480,6 +480,8 @@ class MuchSelect extends HTMLElement {
       slot.addEventListener("slotchange", this._onSlotChange);
     }
 
+    this.updateHiddenInputValueSlot();
+
     this._connected = true;
   }
 
@@ -499,6 +501,17 @@ class MuchSelect extends HTMLElement {
         app.ports.optionsChangedReceiver.send(optionsJson);
         this.updateDimensions();
       });
+    }
+  }
+
+  updateHiddenInputValueSlot() {
+    if (!this.eventsOnlyMode) {
+      const hiddenValueInput = this.querySelector(
+        "[slot='hidden-value-input']"
+      );
+      if (hiddenValueInput) {
+        hiddenValueInput.setAttribute("value", this.parsedSelectedValue);
+      }
     }
   }
 
@@ -655,14 +668,7 @@ class MuchSelect extends HTMLElement {
       );
     }
 
-    if (!this.eventsOnlyMode) {
-      const hiddenValueInput = this.querySelector(
-        "[slot='hidden-value-input']"
-      );
-      if (hiddenValueInput) {
-        hiddenValueInput.setAttribute("value", this.parsedSelectedValue);
-      }
-    }
+    this.updateHiddenInputValueSlot();
   }
 
   customOptionSelected(values) {
@@ -778,6 +784,8 @@ class MuchSelect extends HTMLElement {
       // noinspection JSUnresolvedVariable
       this.appPromise.then((app) => app.ports.valueChangedReceiver.send([]));
     }
+
+    this.updateHiddenInputValueSlot();
   }
 
   set parsedSelectedValue(values) {

--- a/tests/Slots/hidden-input-slot.test.html
+++ b/tests/Slots/hidden-input-slot.test.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<body>
+<script type="module">
+  import { runTests } from '@web/test-runner-mocha';
+  import { expect } from '@esm-bundle/chai';
+  import { html, fixture, nextFrame } from "@open-wc/testing";
+
+  import MuchSelect from "../../dist/much-select.js";
+
+  if (!customElements.get("much-select")) {
+    // Putting guard rails around this because browsers do not like
+    //  having the same custom element defined more than once.
+    window.customElements.define("much-select", MuchSelect);
+  }
+
+  runTests(() => {
+    describe("Slots", () => {
+      describe("hidden-value-input", () => {
+        it("should be populated with the current value on initialization", async () =>  {
+          const el = /** @type {MuchSelect} */ await fixture(html`<much-select selected-value="Tocharians"><input slot="hidden-value-input" type="hidden" name="my-special-value"></much-select>`);
+          expect(el.querySelector("[slot='hidden-value-input']").getAttribute("value")).to.equal("Tocharians");
+        });
+
+        it("should update when the selected value changes", async () =>  {
+          const el = /** @type {MuchSelect} */ await fixture(html`<much-select selected-value="Jangil"><input slot="hidden-value-input" type="hidden" name="my-special-value"></much-select>`);
+          el.setAttribute("selected-value", "Chaouacha");
+          expect(el.querySelector("[slot='hidden-value-input']").getAttribute("value")).to.equal("Chaouacha");
+        });
+      });
+    });
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
This gives the user option to define a `hidden-value-input` slot. This, if it's a hidden input's value will mirror the much-select's value.

https://github.com/DripEmail/much-select-elm/issues/27