### PR TITLE
Hidden value input should be encoded

### DIFF
--- a/public/selected-value-encoding.html
+++ b/public/selected-value-encoding.html
@@ -44,7 +44,7 @@
       In this example we've added the <code>selected-value-encoding="json"</code> attribute. This means that the <code>selected-value=</code> attribute is expected to be in JSON that has <em>also</em> been URI encoded with <code>encodeURIComponent()</code> (or something else that does the same job).
     </p>
     <p>In this case the selected value looks like <code>selected-value="%5B%22Hoki%22%2C%22Gibberfish%22%5D"</code></p>
-    <much-select multi-select="true" selected-value="%5B%22oh%2Cwhere%22%2C%22can%20my%20be%22%5D" selected-value-encoding="json" allow-custom-options>
+    <much-select multi-select="true" selected-value="%5B%22Hoki%22%2C%22Gibberfish%22%5D" selected-value-encoding="json" allow-custom-options>
       <select slot="select-input">
         <option>Gibberfish</option>
         <option>Hoki</option>

--- a/public/slots.html
+++ b/public/slots.html
@@ -235,6 +235,27 @@
     </much-select>
   </div>
 
+  <div>
+    <h3>Hidden Input JSON encoding</h3>
+    <p>
+      If you're using the <code>hidden-value-input</code> and the <code>selected-value-encoding</code> attribute, the value in the hidden input slot will also be encoded.
+    </p>
+    <p>
+      You can use your browser's developer tools to see the hidden input and watch its value change as you change the much-select's value.
+    </p>
+    <much-select selected-value-encoding="json">
+      <select slot="select-input">
+        <option>New South Wales</option>
+        <option>Queensland</option>
+        <option>South Australia</option>
+        <option>Tasmania</option>
+        <option>Victoria</option>
+        <option>Western Australia</option>
+      </select>
+      <input slot="hidden-value-input" type="hidden" name="my-special-value">
+    </much-select>
+  </div>
+
 </div>
 
 <script src="./index.js" type="module"></script>

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -510,7 +510,7 @@ class MuchSelect extends HTMLElement {
         "[slot='hidden-value-input']"
       );
       if (hiddenValueInput) {
-        hiddenValueInput.setAttribute("value", this.parsedSelectedValue);
+        hiddenValueInput.setAttribute("value", this.selectedValue);
       }
     }
   }

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -510,7 +510,13 @@ class MuchSelect extends HTMLElement {
         "[slot='hidden-value-input']"
       );
       if (hiddenValueInput) {
-        hiddenValueInput.setAttribute("value", this.selectedValue);
+        if (this.selectedValue === null) {
+          hiddenValueInput.setAttribute("value", "");
+        } else if (this.selectedValue === undefined) {
+          hiddenValueInput.setAttribute("value", "");
+        } else {
+          hiddenValueInput.setAttribute("value", this.selectedValue);
+        }
       }
     }
   }

--- a/tests/Slots/hidden-input-slot.test.html
+++ b/tests/Slots/hidden-input-slot.test.html
@@ -17,6 +17,12 @@
   runTests(() => {
     describe("Slots", () => {
       describe("hidden-value-input", () => {
+
+        it("should be an empty string if there is no selected value", async () =>  {
+          const el = /** @type {MuchSelect} */ await fixture(html`<much-select><input slot="hidden-value-input" type="hidden" name="my-special-value"></much-select>`);
+          expect(el.querySelector("[slot='hidden-value-input']").getAttribute("value")).to.equal("");
+        });
+
         it("should be populated with the current value on initialization", async () =>  {
           const el = /** @type {MuchSelect} */ await fixture(html`<much-select selected-value="Tocharians"><input slot="hidden-value-input" type="hidden" name="my-special-value"></much-select>`);
           expect(el.querySelector("[slot='hidden-value-input']").getAttribute("value")).to.equal("Tocharians");


### PR DESCRIPTION
The PR fixes an issue with what exactly I was putting in the hidden-value-input slot.

https://github.com/DripEmail/much-select-elm/issues/76