### PR TITLE
Custom options label

### DIFF
--- a/public/custom-options.html
+++ b/public/custom-options.html
@@ -27,7 +27,7 @@
     <p>
       Using the <code>allow-custom-options</code> attribute to allow the user to choose a their own value (one that is not in the list of options).
     </p>
-    <much-select allow-custom-options="true"></much-select>
+    <much-select allow-custom-options></much-select>
     <p>Events:</p>
     <table id="single-select-custom-option-event-log">
       <thead>
@@ -115,6 +115,21 @@
         <option>Itchy and Scrachy Money</option>
         <option>Merits</option>
         <option>Diamonds</option>
+      </select>
+    </much-select>
+  </div>
+
+  <div id="empty-custom-option-label-text">
+    <h3>Empty Custom Options Label</h3>
+    <p>
+      If you <em>just</em> want the value that's being typed in, with no other hints use just <code>allow-custom-options="{{}}"</code>
+    </p>
+    <much-select allow-custom-options="{{}}">
+      <!--suppress HtmlFormInputWithoutLabel -->
+      <select>
+        <option>Back Rubs</option>
+        <option>Baby Sitting</option>
+        <option>Pies</option>
       </select>
     </much-select>
   </div>

--- a/public/custom-options.html
+++ b/public/custom-options.html
@@ -87,6 +87,37 @@
       });
     </script>
   </div>
+
+  <div id="custom-option-label-text">
+    <h3>Set the custom option text</h3>
+    <p>
+      You can set the value of the <code>allow-custom-options=</code> attribute to text that will be used in the dropdown.
+      The default value will be "Add (your value)...".
+    </p>
+    <much-select allow-custom-options="New Currency: ">
+      <!--suppress HtmlFormInputWithoutLabel -->
+      <select>
+        <option>Gold Doubloons</option>
+        <option>Schrute Bucks</option>
+        <option>Credits</option>
+      </select>
+    </much-select>
+  </div>
+
+  <div id="better-custom-option-label-text">
+    <h3>Set the custom option text with a placeholder</h3>
+    <p>
+      If you want to put the typed in value somewhere other than the very end, you can use the placeholder <code>{{}}</code>
+    </p>
+    <much-select allow-custom-options="Create currency {{}}...">
+      <!--suppress HtmlFormInputWithoutLabel -->
+      <select>
+        <option>Itchy and Scrachy Money</option>
+        <option>Merits</option>
+        <option>Diamonds</option>
+      </select>
+    </much-select>
+  </div>
 </div>
 
 

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -59,6 +59,7 @@ import Ports
         ( addOptionsReceiver
         , allowCustomOptionsReceiver
         , blurInput
+        , customOptionHintReceiver
         , customOptionSelected
         , deselectOptionReceiver
         , disableChangedReceiver
@@ -112,6 +113,7 @@ type Msg
     | LoadingAttributeChanged Bool
     | MaxDropdownItemsChanged Int
     | AllowCustomOptionsChanged Bool
+    | CustomOptionHintChanged (Maybe String)
     | DisabledAttributeChanged Bool
     | MulitSelectAttributeChanged Bool
     | SelectedItemStaysInPlaceChanged Bool
@@ -133,6 +135,7 @@ type Msg
 type alias Model =
     { initialValue : List String
     , placeholder : String
+    , customOptionHint : Maybe String
     , selectionMode : SelectionMode
     , options : List Option
     , optionsForTheDropdown : List Option
@@ -421,6 +424,9 @@ update msg model =
             , Cmd.none
             )
 
+        CustomOptionHintChanged maybeString ->
+            ( { model | customOptionHint = maybeString }, Cmd.none )
+
         DisabledAttributeChanged bool ->
             ( { model | disabled = bool }, Cmd.none )
 
@@ -611,13 +617,13 @@ updateModelWithSearchStringChanges : PositiveInt -> String -> List Option -> Mod
 updateModelWithSearchStringChanges maxNumberOfDropdownItems searchString options model =
     let
         optionsUpdatedWithSearchString =
-            OptionSearcher.updateOptions model.selectionMode searchString options
+            OptionSearcher.updateOptions model.selectionMode model.customOptionHint searchString options
     in
     case searchString of
         "" ->
             let
                 updatedOptions =
-                    OptionSearcher.updateOptions model.selectionMode searchString options
+                    OptionSearcher.updateOptions model.selectionMode model.customOptionHint searchString options
                         |> Option.sortOptionsByGroupAndLabel
             in
             { model
@@ -1420,6 +1426,7 @@ makeCommandMessagesWhenValuesChanges selectedOptions maybeSelectedValue =
 type alias Flags =
     { value : String
     , placeholder : String
+    , customOptionHint : Maybe String
     , allowMultiSelect : Bool
     , optionsJson : String
     , loading : Bool
@@ -1510,6 +1517,7 @@ init flags =
     ( { initialValue = initialValues
       , deleteKeyPressed = False
       , placeholder = flags.placeholder
+      , customOptionHint = flags.customOptionHint
       , selectionMode = selectionMode
       , options = optionsWithInitialValueSelected
       , optionsForTheDropdown =
@@ -1568,6 +1576,7 @@ subscriptions _ =
         , optionsChangedReceiver OptionsChanged
         , maxDropdownItemsChangedReceiver MaxDropdownItemsChanged
         , allowCustomOptionsReceiver AllowCustomOptionsChanged
+        , customOptionHintReceiver CustomOptionHintChanged
         , valueCasingDimensionsChangedReceiver ValueCasingWidthUpdate
         , selectOptionReceiver SelectOption
         , deselectOptionReceiver DeselectOption

--- a/src/Option.elm
+++ b/src/Option.elm
@@ -781,8 +781,8 @@ optionValuesEqual option optionValue =
     getOptionValue option == optionValue
 
 
-updateOrAddCustomOption : String -> List Option -> List Option
-updateOrAddCustomOption searchString options =
+updateOrAddCustomOption : Maybe String -> String -> List Option -> List Option
+updateOrAddCustomOption maybeCustomOptionHint searchString options =
     let
         -- If we have an exact match with an existing option don't show the custom
         --  option.
@@ -830,11 +830,31 @@ updateOrAddCustomOption searchString options =
                             False
                 )
                 options
+
+        label =
+            case maybeCustomOptionHint of
+                Just customOptionHint ->
+                    let
+                        parts =
+                            String.split "{{}}" customOptionHint
+                    in
+                    case parts of
+                        [] ->
+                            "Add " ++ searchString ++ "…"
+
+                        [ _ ] ->
+                            customOptionHint ++ searchString
+
+                        first :: second :: _ ->
+                            first ++ searchString ++ second
+
+                Nothing ->
+                    "Add " ++ searchString ++ "…"
     in
     if showAddOption then
         [ CustomOption
             OptionShown
-            (OptionLabel ("Add " ++ searchString ++ "…") Nothing NoSortRank)
+            (OptionLabel label Nothing NoSortRank)
             (OptionValue searchString)
             Nothing
         ]

--- a/src/OptionSearcher.elm
+++ b/src/OptionSearcher.elm
@@ -32,15 +32,15 @@ search string option =
     }
 
 
-updateOptions : SelectionMode -> String -> List Option -> List Option
-updateOptions selectionMode searchString options =
+updateOptions : SelectionMode -> Maybe String -> String -> List Option -> List Option
+updateOptions selectionMode maybeCustomOptionHint searchString options =
     options
-        |> updateOrAddCustomOption searchString selectionMode
+        |> updateOrAddCustomOption maybeCustomOptionHint searchString selectionMode
         |> updateOptionsWithSearchString searchString
 
 
-updateOrAddCustomOption : String -> SelectionMode -> List Option -> List Option
-updateOrAddCustomOption searchString selectionMode options =
+updateOrAddCustomOption : Maybe String -> String -> SelectionMode -> List Option -> List Option
+updateOrAddCustomOption maybeCustomOptionHint searchString selectionMode options =
     case searchString of
         "" ->
             options
@@ -48,7 +48,7 @@ updateOrAddCustomOption searchString selectionMode options =
         _ ->
             case SelectionMode.getCustomOptions selectionMode of
                 AllowCustomOptions ->
-                    Option.updateOrAddCustomOption searchString options
+                    Option.updateOrAddCustomOption maybeCustomOptionHint searchString options
 
                 NoCustomOptions ->
                     options

--- a/src/Ports.elm
+++ b/src/Ports.elm
@@ -2,6 +2,7 @@ port module Ports exposing
     ( addOptionsReceiver
     , allowCustomOptionsReceiver
     , blurInput
+    , customOptionHintReceiver
     , customOptionSelected
     , deselectOptionReceiver
     , disableChangedReceiver
@@ -105,6 +106,9 @@ port maxDropdownItemsChangedReceiver : (Int -> msg) -> Sub msg
 
 
 port allowCustomOptionsReceiver : (Bool -> msg) -> Sub msg
+
+
+port customOptionHintReceiver : (Maybe String -> msg) -> Sub msg
 
 
 port valueCasingDimensionsChangedReceiver : ({ width : Float, height : Float } -> msg) -> Sub msg

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -197,6 +197,12 @@ class MuchSelect extends HTMLElement {
     this._allowCustomOptions = false;
 
     /**
+     * @type {string|null}
+     * @private
+     */
+    this._customOptionHint = null;
+
+    /**
      * @type {boolean}
      * @private
      */
@@ -263,6 +269,7 @@ class MuchSelect extends HTMLElement {
     if (name === "allow-custom-options") {
       if (oldValue !== newValue) {
         this.allowCustomOptions = newValue;
+        this.customOptionHint = newValue;
       }
     } else if (name === "disabled") {
       if (oldValue !== newValue) {
@@ -590,6 +597,7 @@ class MuchSelect extends HTMLElement {
     flags.selectedItemStaysInPlace = this.selectedItemStaysInPlace;
     flags.maxDropdownItems = this.maxDropdownItems;
     flags.allowCustomOptions = this.allowCustomOptions;
+    flags.customOptionHint = this.customOptionHint;
 
     const selectElement = this.querySelector("select");
     if (selectElement) {
@@ -963,6 +971,33 @@ class MuchSelect extends HTMLElement {
     // noinspection JSUnresolvedVariable
     this.appPromise.then((app) =>
       app.ports.allowCustomOptionsReceiver.send(this._allowCustomOptions)
+    );
+  }
+
+  get customOptionHint() {
+    return this._customOptionHint;
+  }
+
+  set customOptionHint(value) {
+    if (value === "false") {
+      this._customOptionHint = null;
+    } else if (value === "true") {
+      this._customOptionHint = null;
+    } else if (value === null) {
+      this._customOptionHint = null;
+    } else if (value === "") {
+      this._customOptionHint = "";
+    } else if (typeof value === "string") {
+      this._customOptionHint = value;
+    } else {
+      throw new TypeError(
+        `Unexpected type for the customOptionHint, it should be a string but instead it is a: ${typeof value}`
+      );
+    }
+
+    // noinspection JSUnresolvedVariable
+    this.appPromise.then((app) =>
+      app.ports.customOptionHintReceiver.send(this._customOptionHint)
     );
   }
 

--- a/src/much-select.js
+++ b/src/much-select.js
@@ -986,7 +986,7 @@ class MuchSelect extends HTMLElement {
     } else if (value === null) {
       this._customOptionHint = null;
     } else if (value === "") {
-      this._customOptionHint = "";
+      this._customOptionHint = null;
     } else if (typeof value === "string") {
       this._customOptionHint = value;
     } else {


### PR DESCRIPTION
Allowing the label around custom options to be specifed through the `allow-custom-options` attribute.


https://github.com/DripEmail/much-select-elm/issues/74