### PR TITLE
run-pty fix and some CSS stuff

### DIFF
--- a/run-pty.json
+++ b/run-pty.json
@@ -48,7 +48,13 @@
       "soupault.toml",
       "--",
       "soupault"
-    ]
+    ],
+    "defaultStatus": ["⏳", "W"],
+    "status": {
+      "Running": ["⏳", "W"],
+      "command not found": ["🚨", "E"],
+      "Command was successful": ["✅", "+"]
+    }
   },
   {
     "title": "Run web server http://localhost:1234",

--- a/site/demo-styles.css
+++ b/site/demo-styles.css
@@ -57,7 +57,7 @@ body {
     --london-square: #808e9b;
     --black-pearl: #1e272e;
 
-    --much-select-height: 1.5em;
+    --much-select-height: 2.5em;
     --comic-sans: 'Comic Sans MS', cursive, sans-serif;
 }
 
@@ -77,7 +77,7 @@ body {
     --header-font: system-ui;
     --body-font: system-ui;
     --form-font: system-ui;
-    --value-font-size: 20px;
+    --value-font-size: 1em;
 }
 
 
@@ -85,15 +85,8 @@ body {
     --header-font: var(--comic-sans), sans-serif;
     --body-font: system-ui, sans-serif ;
     --form-font: system-ui, sans-serif;
-    --value-font-size: 25px;
+    --value-font-size: 1em;
 }
-
-/*--border-right:#D0D4CA;*/
-/*--white:#f1f1f1;*/
-/*--red:#FF0000;*/
-/*--border-left:#718093;*/
-/*--black:#000000;*/
-
 
 @media (prefers-color-scheme: light) {
     #theme-switch-boring:checked ~ #page-wrapper {
@@ -477,11 +470,6 @@ much-select::part(value-casing output-style-datalist) {
     cursor: pointer;
 }
 
-much-select::part(right-slot-wrapper) {
-    border-left: 2px dotted var(--much-select-border-color);
-
-}
-
 much-select::part(right-slot-for-all-values-wrapper) {
     position: absolute;
     right: 0;
@@ -492,6 +480,7 @@ much-select::part(right-slot-for-all-values-wrapper) {
     align-items: center;
     flex-direction: column;
     justify-content: center;
+    border-left: 2px dotted var(--much-select-border-color);
 }
 
 much-select::part(input-value) {
@@ -598,7 +587,6 @@ much-select::part(input-filter):hover, much-select::part(input-filter):focus {
 }
 
 much-select[multi-select]::part(selected-value) {
-    padding: 0.25rem;
     color: var(--much-select-multi-select-selected-value-color);
     background-image: var(--much-select-multi-select-selected-value-background-image);
     background-repeat: repeat-x;
@@ -609,6 +597,14 @@ much-select[multi-select]::part(selected-value) {
     flex-grow: 0;
     flex-shrink: 1;
     flex-basis: auto;
+
+    /* Make sure the label is always vertically centered */
+    display: flex;
+    align-items: center;
+
+    /* Add a little space between the border and the label */
+    padding-left: 0.25em;
+    padding-right: 0.25em;
 }
 
 much-select::part(selected-value) {


### PR DESCRIPTION
Fixing several things including:

- The static site generation (for the demo/sandbox) was failing but that was not being reflected in `run-pty`.
- In multi select mode The labels should always be vertically aligned in the center.
- In several different modes the height of the much select was not consistent. It's probably still bigger than I would like, but at least now it's consistent.