### PR TITLE
Add a new css variable for the text color of the optgroup labels.

### DIFF
--- a/site/demo-styles.css
+++ b/site/demo-styles.css
@@ -117,10 +117,11 @@ body {
         --much-select-dropdown-option-background-color: var(--lynx-white);
         --much-select-dropdown-option-highlighted-background-color: var(--matt-purple);
         --much-select-dropdown-option-active-background-color: var(--protoss-pylon);
-        --much-select-dropdown-option-selected-background-color: var(--chain-gang-grey);
+        --much-select-dropdown-option-selected-background-color: var(--vanadyl-blue);
         --much-select-dropdown-option-disabled-background-color: var(--blueberry-soda);
         --much-select-dropdown-option-disabled-font-color: var(--chain-gang-grey);
-        --much-select-dropdown-optgroup-background-color: var(--skirret-green);
+        --much-select-dropdown-optgroup-color: var(--hint-of-pensive);
+        --much-select-dropdown-optgroup-background-color: var(--chain-gang-grey);
         --much-select-dropdown-footer-color: var(--chain-gang-grey);
         --much-select-dropdown-footer-background-color: var(--hint-of-pensive);
     }
@@ -165,6 +166,7 @@ body {
         --much-select-dropdown-option-selected-background-color: var(--fresh-turquoise);
         --much-select-dropdown-option-disabled-background-color: var(--london-square);
         --much-select-dropdown-option-disabled-font-color: var(--hint-of-elusive-blue);
+        --much-select-dropdown-optgroup-color: var(--yriel-yellow);
         --much-select-dropdown-optgroup-background-color: var(--green-teal);
         --much-select-dropdown-footer-color: var(--yriel-yellow);
         --much-select-dropdown-footer-background-color: var(--red-orange);
@@ -201,6 +203,7 @@ body {
         --much-select-dropdown-option-selected-background-color: var(--periwinkle);
         --much-select-dropdown-option-disabled-background-color: var(--london-square);
         --much-select-dropdown-option-disabled-font-color: var(--hint-of-elusive-blue);
+        --much-select-dropdown-optgroup-color: var(--hint-of-elusive-blue);
         --much-select-dropdown-optgroup-background-color: var(--blue-nights);
         --much-select-dropdown-footer-color: var(--hint-of-pensive);
         --much-select-dropdown-footer-background-color: var(--chain-gang-grey);
@@ -241,6 +244,7 @@ body {
         --much-select-dropdown-option-selected-background-color: var(--black-pearl);
         --much-select-dropdown-option-disabled-background-color: var(--london-square);
         --much-select-dropdown-option-disabled-font-color: var(--black-pearl);
+        --much-select-dropdown-optgroup-color: var(--chrome-yellow);
         --much-select-dropdown-optgroup-background-color: var(--london-square);
         --much-select-dropdown-footer-color: var(--minty-green);
         --much-select-dropdown-footer-background-color: var(--dark-periwinkle);
@@ -669,6 +673,7 @@ much-select::part(dropdown) {
 }
 
 much-select::part(dropdown-optgroup) {
+    color: var(--much-select-dropdown-optgroup-color);
     background-color: var(--much-select-dropdown-optgroup-background-color);
     font-size: 0.85rem;
     font-weight: 300;


### PR DESCRIPTION
This should address #115.

The CSS variable means we're not just using the same color for the text in the dropdown options.