### PR TITLE
CSS improvements to the empty state

### DIFF
--- a/dist/much-select-elm-debug.js
+++ b/dist/much-select-elm-debug.js
@@ -20487,7 +20487,8 @@ var $author$project$MuchSelect$customHtmlDropdown = F4(
 				$elm$html$Html$div,
 				_List_fromArray(
 					[
-						$elm$html$Html$Attributes$class('option disabled')
+						$elm$html$Html$Attributes$class('option disabled no-options'),
+						A2($elm$html$Html$Attributes$attribute, 'part', 'no-options')
 					]),
 				_List_fromArray(
 					[

--- a/dist/much-select-elm.js
+++ b/dist/much-select-elm.js
@@ -15222,7 +15222,8 @@ var $author$project$MuchSelect$customHtmlDropdown = F4(
 				$elm$html$Html$div,
 				_List_fromArray(
 					[
-						$elm$html$Html$Attributes$class('option disabled')
+						$elm$html$Html$Attributes$class('option disabled no-options'),
+						A2($elm$html$Html$Attributes$attribute, 'part', 'no-options')
 					]),
 				_List_fromArray(
 					[

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -47,5 +47,9 @@ export default [
     rules: {
       "no-unused-expressions": "off",
     },
+    plugins: {
+      prettier,
+      html,
+    },
   },
 ];

--- a/examples/empty-option-with-label-and-other-options-2.html
+++ b/examples/empty-option-with-label-and-other-options-2.html
@@ -1,6 +1,5 @@
 <div id="an-empty-option-with-no-label-and-some-other-options">
   <h3>An Empty Option with a Label and other options</h3>
-  <p><strong>TODO this is working quite right. Could just be a styling issue.</strong></p>
   <much-select>
     <select slot="select-input">
       <option value=""></option>,

--- a/site/demo-styles.css
+++ b/site/demo-styles.css
@@ -715,6 +715,12 @@ much-select::part(dropdown-option) {
     padding: 0.5rem;
     cursor: pointer;
     font-size: var(--value-font-size);
+
+    /** Throw in a min height so options without labels are not
+     so short but take up the same vertical space as options with
+     labels
+     **/
+    min-height: 1.2rem;
 }
 
 much-select::part(dropdown-option selected) {
@@ -751,7 +757,10 @@ much-select::part(dropdown-footer) {
     color: var(--much-select-dropdown-footer-color);
     background-color: var(--much-select-dropdown-footer-background-color);
     padding: 0.2rem;
+}
 
+much-select::part(no-options) {
+    padding: 0.2rem;
 }
 
 

--- a/src/MuchSelect.elm
+++ b/src/MuchSelect.elm
@@ -2982,7 +2982,12 @@ customHtmlDropdown selectionMode options searchString (ValueCasing valueCasingWi
         optionsHtml =
             -- TODO We should probably do something different if we are in a loading state
             if DropdownOptions.isEmpty optionsForTheDropdown then
-                [ div [ class "option disabled" ] [ node "slot" [ name "no-options" ] [ text "No available options" ] ] ]
+                [ div
+                    [ class "option disabled no-options"
+                    , Html.Attributes.attribute "part" "no-options"
+                    ]
+                    [ node "slot" [ name "no-options" ] [ text "No available options" ] ]
+                ]
 
             else if doesSearchStringFindNothing searchString (getSearchStringMinimumLength selectionMode) optionsForTheDropdown then
                 [ div [ class "option disabled" ] [ node "slot" [ name "no-filtered-options" ] [ text "This filter returned no results." ] ] ]


### PR DESCRIPTION
Fixing 2 issues that were coming up when we had an empty option.

- a blank (empty) option label
- if there are no options

So many different empty states